### PR TITLE
Fix to outboundProvider promises

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,19 +150,19 @@ This section is a walkthrough of some of the examples found in `./examples`
 
 ## Typescript
 
-If you are implementing this into a typescript project you can use the `IOutboundProvider` interface to help you define the outbound provider .
+If you are implementing this into a typescript project you can use the `IOutboundProvider` interface to help you define the outbound provider (and the `IProviderReq` interface to define the object passed in to the provider).
 
 ```
 // import IOutboundProvider interface to
 // help define the outbound provider class
-import {IOutboundProvider} from 'coronado-bridge'
+import {IOutboundProvider, IProviderReq} from 'coronado-bridge'
 
 // Our outbound provider class implements the
 // IOutboundProvider interface
 class OutboundConsole implements IOutboundProvider {
 
     // The handler method receives a req and returns a Promise
-    handler(req: object): Promise<void> {
+    handler(req: IProviderReq): Promise<void> {
         return new Promise((resolve, reject)=>{
             console.log(req)
             resolve()
@@ -172,6 +172,28 @@ class OutboundConsole implements IOutboundProvider {
 
 export default OutboundConsole
 ```
+
+You can also return `data` from an outbound provider's Promise:
+
+```
+// import IOutboundProvider interface to
+// help define the outbound provider class
+import {IOutboundProvider, IProviderReq} from 'coronado-bridge'
+
+// Our outbound provider class implements the
+// IOutboundProvider interface
+class OutboundConsole implements IOutboundProvider {
+
+    // The handler method receives a req and returns a Promise
+    handler(req: IProviderReq): Promise<any> {
+        return new Promise((resolve, reject)=>{
+            console.log(req)
+            resolve('Logged data to the console.')
+        })
+    }
+}
+```
+
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The `handler` function is passed a req object. The req object has the request bo
 
 Outbound Provider req Object:
 
-```
+```js
 {
   body: {id: 1, name: Shane, page: 33},
   query: {page:54, loc:'USA'},
@@ -37,7 +37,7 @@ Outbound Provider req Object:
 
 **Example Class:**
 
-```
+```js
 class OutboundConsole {
     handler(req) {
         // Returns a promise
@@ -74,7 +74,7 @@ $ npm install coronado-bridge
 
 ## Import
 
-```
+```js
 //ES6
 import CoronadoBridge from 'coronado-bridge'
 
@@ -96,7 +96,7 @@ The package has some configuration options.
 
 **Example**:
 
-```
+```js
 import CoronadoBridge from 'coronado-bridge'
 // Our outbound provider class which implements a
 // handler function that writes messages to a file.
@@ -124,7 +124,7 @@ new CoronadoBridge(config);
 
 This package is built with typescript. If you are implementing this into a typescript project you can use the `ICoronadoBridgeConfig` interface to help you define the configuration object.
 
-```
+```ts
 import CoronadoBridge, {ICoronadoBridgeConfig} from 'coronado-bridge'
 import OutboundFile from './providers/OutboundFile'
 import logger from './providers/CustomLogger'
@@ -152,7 +152,7 @@ This section is a walkthrough of some of the examples found in `./examples`
 
 If you are implementing this into a typescript project you can use the `IOutboundProvider` interface to help you define the outbound provider (and the `IProviderReq` interface to define the object passed in to the provider).
 
-```
+```ts
 // import IOutboundProvider interface to
 // help define the outbound provider class
 import {IOutboundProvider, IProviderReq} from 'coronado-bridge'
@@ -175,7 +175,7 @@ export default OutboundConsole
 
 You can also return `data` from an outbound provider's Promise:
 
-```
+```ts
 // import IOutboundProvider interface to
 // help define the outbound provider class
 import {IOutboundProvider, IProviderReq} from 'coronado-bridge'
@@ -199,7 +199,7 @@ class OutboundConsole implements IOutboundProvider {
 
 This package exports a CoronadoBridgeError class to handle errors in your outbound provider. The `constructor` requires two properties. A http status code and a error message.
 
-```
+```ts
 // Import the CoronadoBridgeError class
 import { IOutboundProvider, CoronadoBridgeError } from 'coronado-bridge';
 
@@ -232,7 +232,7 @@ The outbound custom file example is an extension of the OutboundFile outbound pr
 
 **Example Request**: `POST /?id=2&type=camera`
 
-```
+```ts
 // Define expected message
 interface IHandlerReq {
   query: {
@@ -298,7 +298,7 @@ To run some of the examples located in `./examples`, simple run the scripts outl
 
 Can be used with all examples
 
-```
+```bash
 curl --location --request POST 'http://localhost:3000/' \
 --header 'Content-Type: application/json' \
 --data-raw '{
@@ -315,7 +315,7 @@ curl --location --request POST 'http://localhost:3000/' \
 
 Can be used with the `custom-file` example
 
-```
+```bash
 curl --location --request POST 'http://localhost:3000/?id=2&type=camera' \
 --header 'Content-Type: application/json' \
 --data-raw '{

--- a/examples/src/providers/OutboundConsole.ts
+++ b/examples/src/providers/OutboundConsole.ts
@@ -1,7 +1,7 @@
-import { IOutboundProvider } from 'coronado-bridge';
+import { IOutboundProvider, IProviderReq } from 'coronado-bridge';
 
 export default class OutboundConsole implements IOutboundProvider {
-  handler(req: object): Promise<void> {
+  handler(req: IProviderReq): Promise<void> {
     return new Promise((resolve, reject) => {
       console.log(req);
       resolve();

--- a/examples/src/providers/OutboundFile.ts
+++ b/examples/src/providers/OutboundFile.ts
@@ -1,4 +1,4 @@
-import { IOutboundProvider } from 'coronado-bridge';
+import { IOutboundProvider, IProviderReq } from 'coronado-bridge';
 import fs from 'fs';
 
 export interface IOutboundFileConfig {
@@ -12,7 +12,7 @@ class OutboundFile implements IOutboundProvider {
     this.filePath = config.filePath;
   }
 
-  handler(message: object): Promise<void> {
+  handler(message: IProviderReq): Promise<void> {
     return new Promise((resolve, reject) => {
       let messages: Array<object> = [];
       fs.exists(this.filePath, exists => {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -71,7 +71,7 @@ class CoronadoBridge {
           .handler(providerReq)
           .then(data => {
             if (this.logger) {
-              this.logger.info(`CoronadoBridge - handler processed message`);
+              this.logger.info(`CoronadoBridge - handler processed message`); 
             }
             res.status(200).send(data);
           })

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -8,7 +8,7 @@ import BridgeError from './bridge-error';
 interface IProviderReq {
   body: object;
   query: object;
-  params?: object;
+  params?: Array<string>;
 }
 
 class CoronadoBridge {

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,15 +1,9 @@
 import express from 'express';
 import { Logger } from 'log4js';
 import { IBridgeConfig } from './index';
-import { IOutboundProvider } from './provider';
+import { IOutboundProvider, IProviderReq } from './provider'; 
 
 import BridgeError from './bridge-error';
-
-interface IProviderReq {
-  body: object;
-  query: object;
-  params?: Array<string>;
-}
 
 class CoronadoBridge {
   private outboundProvider: IOutboundProvider;

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -75,11 +75,11 @@ class CoronadoBridge {
         }
         this.outboundProvider
           .handler(providerReq)
-          .then(() => {
+          .then(data => {
             if (this.logger) {
               this.logger.info(`CoronadoBridge - handler processed message`);
             }
-            res.sendStatus(200);
+            res.status(200).send(data);
           })
           .catch(error => {
             if (error instanceof BridgeError) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import CoronadoBridge from './bridge';
 import { Logger } from 'log4js';
 
-import { IOutboundProvider } from './provider';
+import { IOutboundProvider, IProviderReq } from './provider';
 
 import BridgeError from './bridge-error';
 
@@ -13,4 +13,4 @@ export interface IBridgeConfig {
 
 export default CoronadoBridge;
 
-export { IOutboundProvider, BridgeError };
+export { IOutboundProvider, BridgeError, IProviderReq };

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,3 +1,9 @@
+export interface IProviderReq {
+  body: object;
+  query: object;
+  params?: Array<string>;
+}
+
 export interface IOutboundProvider {
-  handler(message: object): Promise<void>;
+  handler(message: IProviderReq): Promise<any>;
 }


### PR DESCRIPTION
Fix to 

- allow `outboundProvider` handlers to return promises with `data`
- export `IProviderReq` interface for outbound providers to use
- add notes to README and added syntax highlighting to code blocks