### PR TITLE
Minor fixes to no-TypeScript examples. 

### DIFF
--- a/examples/src/file-no-typescript.js
+++ b/examples/src/file-no-typescript.js
@@ -6,7 +6,7 @@ import logger from './providers/CustomLogger';
  * This provider comes with a configuration interface,
  * BUT we are not using typescript so we will not import it.
  */
-import OutboundFile from './providers/OutboundFile';
+import OutboundFileJS from './providers/OutboundFileJS';
 
 /*
  * OutboundProvider Config.
@@ -26,7 +26,7 @@ const outboundFileConfig = {
 const config = {
   ports: [3000, 3002],
   logger,
-  outboundProvider: new OutboundFile(outboundFileConfig),
+  outboundProvider: new OutboundFileJS(outboundFileConfig),
 };
 
 new CoronadoBridge(config);

--- a/examples/src/providers/OutboundFileJS.js
+++ b/examples/src/providers/OutboundFileJS.js
@@ -6,7 +6,7 @@ class OutboundFileJS {
   }
 
   handler(message) {
-    return new Promsie((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       let messages = [];
       fs.exists(this.filePath, exists => {
         if (exists) {


### PR DESCRIPTION
- Fixed typo in `Promise` declaration
- Pointed to `OutboundFileJS` instead of `OutboundFile` in `file-no-typescript.js`